### PR TITLE
fix APPle brand typo

### DIFF
--- a/src/data/products.json
+++ b/src/data/products.json
@@ -93,7 +93,7 @@
     "discountPercentage": 11.02,
     "rating": 4.57,
     "stock": 83,
-    "brand": "APPle",
+    "brand": "Apple",
     "category": "laptops",
     "thumbnail": "https://i.dummyjson.com/data/products/6/thumbnail.png",
     "images": [


### PR DESCRIPTION
Hi, thanks for the convenient service.

I am currently building a prototype using this API. I found that there is a product with the brand "APPle". I am guessing that maybe it's a typo. So, I made this little PR. 
