### PR TITLE
🍪 Add support for cookies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@aws-sdk/client-s3": "^3.485.0",
     "color-convert": "^2.0.1",
     "compression": "^1.7.4",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "ejs": "^3.1.6",
     "express": "^4.17.1",

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -4,7 +4,12 @@ const { findUserWithUsernameAndId } = require('../utils/util');
 
 const authUser = async (req, res, next) => {
   try {
-    const token = req.header('Authorization');
+    const tokenFromHeader = req.header('Authorization');
+    const tokenFromCookie = req.cookies.accessToken;
+
+    // Prefer token from Authorization header if both are present
+    const token = tokenFromHeader || tokenFromCookie;
+
     if (!token) throw new APIError('Authentication Problem', 403);
 
     const decoded = await verifyAccessToken(token);

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const compression = require('compression');
 const helmet = require('helmet');
 const cors = require('cors');
+const cookieParser = require('cookie-parser');
 
 const applyRateLimit = require('../utils/applyRateLimit');
 const logger = require('./logger');
@@ -17,6 +18,9 @@ function injectMiddleWares(app) {
 
   // use helmet JS.
   app.use(helmet());
+
+  // apply cookie-parser middleware
+  app.use(cookieParser());
 
   app.use(express.json({ limit: '300kb' })); // for parsing application/json
   app.use(express.urlencoded({ extended: true })); // for parsing application/x-www-form-urlencoded

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -24,8 +24,13 @@ router.get('/', (req, res) => {
 router.post('/login', async (req, res, next) => {
   try {
     const payload = await loginByUsernamePassword(req.body);
+    const { accessToken, refreshToken, cookieData, ...payloadData } = payload;
 
-    res.send(payload);
+    res.cookie('accessToken', accessToken, cookieData);
+    res.cookie('refreshToken', refreshToken, cookieData);
+
+    // sending accessToken as token for backward compatibility
+    res.send({ token: accessToken, refreshToken, ...payloadData });
   } catch (error) {
     next(error);
   }


### PR DESCRIPTION
**Resolves #75**

### Summary:

- 🚀 Added cookie support for `/login`, with `accessToken` and `refreshToken` included as HTTP cookies 🍪.
- 🔒 Tokens are secured with `HttpOnly` and `Secure` flags for enhanced security.
- 🔄 The `/auth/refresh` endpoint now refreshes both cookies.
