### PR TITLE
Changed thumbnail background to be transparent

### DIFF
--- a/raw/products/products-data-generator.js
+++ b/raw/products/products-data-generator.js
@@ -169,7 +169,7 @@ function generateThumbnailImage(product) {
   const image = `${dir}/${folder[0]}`;
 
   const sharpImage = sharp(image);
-  const resizedImage = sharpImage.resize({ width: 300, height: 300, fit: 'contain', background: "transparent" });
+  const resizedImage = sharpImage.resize({ width: 300, height: 300, fit: 'contain', background: 'transparent' });
   const pngImage = resizedImage.png();
 
   if (fs.existsSync(`${dir}/thumbnail.png`)) {

--- a/raw/products/products-data-generator.js
+++ b/raw/products/products-data-generator.js
@@ -169,7 +169,7 @@ function generateThumbnailImage(product) {
   const image = `${dir}/${folder[0]}`;
 
   const sharpImage = sharp(image);
-  const resizedImage = sharpImage.resize({ width: 300, height: 300, fit: 'contain' });
+  const resizedImage = sharpImage.resize({ width: 300, height: 300, fit: 'contain', background: "transparent" });
   const pngImage = resizedImage.png();
 
   if (fs.existsSync(`${dir}/thumbnail.png`)) {


### PR DESCRIPTION
When resizing images that are not square, `sharp` library adds black background. 
This PR addresses this by changing the background to be transparent, in case someone wants to show the thumbnails.

This change was tested in isolation - the code in question `generateThumbnailImage` was extracted to a separate project with same `sharp` dependency, adjusted and tested to match the expected behavior,