### PR TITLE
🐛 Fix: Ensure `expiresInMins` is passed to token generator in `/auth/refresh`

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -26,7 +26,8 @@ constants.imageMimeTypes = {
 
 constants.allowedImageTypes = Object.keys(constants.imageMimeTypes);
 
-constants.thirtyDaysInMints = 30 * 24 * 60;
+// 30 days in minutes
+constants.maxTokenExpireMins = 30 * 24 * 60;
 
 constants.customResponseExpiresInDays = 90;
 

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -55,7 +55,7 @@ controller.loginByUsernamePassword = async data => {
 };
 
 // get new refresh token
-controller.getNewRefreshToken = async ({ refreshToken, expiresInMins }) => {
+controller.getNewRefreshToken = async ({ refreshToken, expiresInMins = 60 }) => {
   if (!refreshToken) {
     throw new APIError(`Refresh token required`, 401);
   }
@@ -79,7 +79,7 @@ controller.getNewRefreshToken = async ({ refreshToken, expiresInMins }) => {
 
   const payload = getUserPayload(user);
 
-  const newAccessToken = await generateAccessToken(payload);
+  const newAccessToken = await generateAccessToken(payload, expiresInMins);
   const newRefreshToken = await generateRefreshToken(payload, maxAccessTokenExpireTime);
 
   return { accessToken: newAccessToken, refreshToken: newRefreshToken };

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -1,5 +1,5 @@
 const jwt = require('jsonwebtoken');
-const { thirtyDaysInMints } = require('../constants');
+const { maxTokenExpireMins } = require('../constants');
 
 const { JWT_SECRET } = process.env;
 
@@ -12,7 +12,8 @@ util.verifyAccessToken = authorization => {
   return verifyToken(accessToken);
 };
 
-util.generateRefreshToken = generateToken;
+// refresh token is always valid for 30 days
+util.generateRefreshToken = payload => generateToken(payload, maxTokenExpireMins);
 
 util.verifyRefreshToken = verifyToken;
 
@@ -20,7 +21,7 @@ module.exports = util;
 
 function generateToken(payload, expiresInMins) {
   return new Promise((resolve, reject) => {
-    let expiresIn = `${thirtyDaysInMints}m`;
+    let expiresIn = `${maxTokenExpireMins}m`;
 
     if (expiresInMins) expiresIn = `${expiresInMins}m`;
 


### PR DESCRIPTION
- Fixed by correctly forwarding the `expiresInMins` parameter to the token generator, ensuring tokens reflect the intended expiration time.
- Added a default `expiresInMins` value of 60 minutes as per documentation.

This resolves the issue where tokens always had a fixed expiration of 30 days, regardless of the input.
