### PR TITLE
fix link text for user sorting documentation

### DIFF
--- a/views/docs-users.ejs
+++ b/views/docs-users.ejs
@@ -394,7 +394,7 @@
       </div>
 
       <div class="resource" id="users-sort">
-        <a href="#users-sort" class="res-title">Limit and skip users</a>
+        <a href="#users-sort" class="res-title">Sort and order users</a>
         <p class="res-tip">
           You can pass `sortBy` and `order` params to sort the results,
           `sortBy` should be field name and `order` should be "asc" or "desc"


### PR DESCRIPTION
Fixes the duplicate title 'Limit and skip users' on the sort and order section.