### PR TITLE
fix: assign product quantities by id match instead of index in addNew…

### DIFF
--- a/src/controllers/cart.js
+++ b/src/controllers/cart.js
@@ -79,9 +79,9 @@ export const addNewCart = ({ userId, products = [] }) => {
   let totalQuantity = 0;
 
   // get products in the relevant schema
-  const someProducts = productsByIds.map((p, idx) => {
-    // get quantity of the product
-    const quantity = productQty[idx];
+  const someProducts = productsByIds.map((p) => {
+    const originalIndex = productIds.indexOf(p.id); // match by id
+    const quantity = productQty[originalIndex];
 
     // total price (price * quantity)
     const priceWithQty = p.price * quantity;


### PR DESCRIPTION
Bug: Wrong quantities assigned to products in addNewCart
Problem
When adding a cart, product quantities were being assigned by index after filtering from frozenData.products. Since filter returns products in their stored order rather than the order they were passed in the request, the quantities were mismatched — e.g. sending {id:6, qty:1}, {id:4, qty:3} would result in id:6 getting qty:3 and id:4 getting qty:1.
Fix
Instead of relying on index to match quantities, we now use productIds.indexOf(p.id) to look up the correct quantity for each product by its id, regardless of the order products are returned from the data store.